### PR TITLE
Jlc/fix cdn and css vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "semantic-release": "semantic-release",
     "start": "fedx-scripts webpack-dev-server --progress",
     "test": "TZ=GMT fedx-scripts jest --coverage --passWithNoTests",
-    "watch-tests": "jest --watch"
+    "watch-tests": "jest --watch",
+    "replace-variables": "paragon replace-variables -p src -t usage"
   },
   "author": "edX",
   "license": "AGPL-3.0",

--- a/src/App.scss
+++ b/src/App.scss
@@ -8,7 +8,7 @@ $fa-font-path: "~font-awesome/fonts";
 @import "~font-awesome/scss/font-awesome";
 
 // $input-focus-box-shadow: $input-box-shadow; // hack to get upgrade to paragon 4.0.0 to work
-$input-focus-box-shadow: var(--pgn-elevation-input-btn-focus-box-shadow);
+$input-focus-box-shadow: var(--pgn-elevation-form-input-base); // cherry-pick style
 
 @import "~@edx/frontend-component-header/dist/index";
 @import "~@edx/frontend-component-footer/dist/_footer";

--- a/src/components/GradesView/GradesView.scss
+++ b/src/components/GradesView/GradesView.scss
@@ -120,7 +120,7 @@ select#ScoreView.form-control {
     
     &:before {
         border-width: 0.4rem 0.4rem 0.4rem 0;
-        border-right-color: $black;
+        border-right-color: var(--pgn-color-black);
     }
 }
 

--- a/src/data/constants/app.js
+++ b/src/data/constants/app.js
@@ -1,7 +1,7 @@
 import { StrictDict } from 'utils';
-import { getConfig } from '@edx/frontend-platform';
+import { getConfig, getPath } from '@edx/frontend-platform';
 
-export const routePath = `${getConfig().PUBLIC_PATH}:courseId`;
+export const routePath = `${getPath(getConfig().PUBLIC_PATH)}:courseId`;
 
 export const views = StrictDict({
   grades: 'grades',


### PR DESCRIPTION
# Description
Fix CDN
This fix the built option to work with CDN.



**Testing Instructions**

Deployed in stage using the caddy gradebook-matcher and know the built works with PUBLIC_PATH using CDN.
## Before

Gradebook MFE with CDN doesn't load.
![2024-04-22_11-20](https://github.com/nelc/frontend-app-gradebook/assets/51926076/0b67347e-b6a3-463c-af31-776f9ac14bd4)

## After
![2024-04-22_10-53](https://github.com/nelc/frontend-app-gradebook/assets/51926076/978ec5b4-0d8a-4b9f-82f0-1664d867fc58)

### Jira story
https://edunext.atlassian.net/browse/FUTUREX-739
