### PR TITLE
fix: runtime load logo for footer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
+import { getConfig } from '@edx/frontend-platform';
 import { AppProvider } from '@edx/frontend-platform/react';
 
 import Footer from '@edx/frontend-component-footer';
@@ -27,7 +28,7 @@ const App = () => (
             />
           </Switch>
         </main>
-        <Footer logo={process.env.LOGO_POWERED_BY_OPEN_EDX_URL_SVG} />
+        <Footer logo={getConfig().LOGO_TRADEMARK_URL || process.env.LOGO_POWERED_BY_OPEN_EDX_URL_SVG} />
       </div>
     </Router>
   </AppProvider>


### PR DESCRIPTION
# Description
as you can see if logo is not falsy, the runtimevalue doesnt work.

https://github.com/openedx/frontend-component-footer/blob/master/src/components/Footer.jsx#L59

but gradebook loaded with this value

https://github.com/openedx/frontend-app-gradebook/blob/open-release/palm.master/src/App.jsx#L30


**Testing Instructions**

Add setting for footer logo in mfe runtime.
eg 
``` python
MFE_CONFIG["LOGO_TRADEMARK_URL"] = "https://stage.nelp.gov.sa/theming/asset/images/logo.png"
```
## Before
![2024-04-23_12-40](https://github.com/nelc/frontend-app-gradebook/assets/51926076/72aaad95-6319-4a74-ae5e-cf993b6686f4)


## after
![2024-04-23_12-43](https://github.com/nelc/frontend-app-gradebook/assets/51926076/f0e4857e-7195-4786-b9a8-c7bbd146dfa4)
