### PR TITLE
feat: add custom necl dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.6.2",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+        "@edx/brand": "github:nelc/brand-openedx#open-release/redwood.nelp",
         "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1",
-        "@edx/frontend-platform": "npm:@edunext/frontend-platform@7.1.2-alpha.1",
+        "@edx/frontend-platform": "npm:@edunext/frontend-platform@^7.1.2-alpha-nelc.1",
         "@edx/openedx-atlas": "^0.6.0",
         "@edx/react-unit-test-utils": "npm:@edunext/react-unit-test-utils@2.0.0-alpha.1",
         "@edx/reactifex": "^2.1.1",
@@ -2137,9 +2137,9 @@
     },
     "node_modules/@edx/brand": {
       "name": "@openedx/brand-openedx",
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
+      "version": "1.0.0-semantically-released",
+      "resolved": "git+ssh://git@github.com/nelc/brand-openedx.git#26a12963086817ccb9cf2d4bcda3bcc1bd944236",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/browserslist-config": {
       "version": "1.2.0",
@@ -3717,8 +3717,10 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "7.1.2-alpha.1",
-      "resolved": "git+ssh://git@github.com/edunext/frontend-platform.git#f85f54828a3a0598408832bfad91a614ccf7464a",
+      "name": "@edunext/frontend-platform",
+      "version": "7.1.2-alpha-nelc.1",
+      "resolved": "https://registry.npmjs.org/@edunext/frontend-platform/-/frontend-platform-7.1.2-alpha-nelc.1.tgz",
+      "integrity": "sha512-UearJi4Mh5a1twdLxVCPGk/jnRcCAyKk2aPWQEU6Vw/VYmugMBcTAKH0pvxqdClN1qiWw5Jhi0ygiF8VTNgs3g==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -5845,6 +5847,12 @@
         "react-error-boundary": "^4.0.11"
       }
     },
+    "node_modules/@openedx/frontend-plugin-framework/node_modules/@edx/brand": {
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
+      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
+    },
     "node_modules/@openedx/frontend-plugin-framework/node_modules/core-js": {
       "version": "3.37.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
@@ -6067,6 +6075,12 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/@openedx/frontend-slot-footer/node_modules/@edx/brand": {
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
+      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
     },
     "node_modules/@openedx/frontend-slot-footer/node_modules/@edx/eslint-config": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "extends @edx/browserslist-config"
   ],
   "dependencies": {
-    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+    "@edx/brand": "github:nelc/brand-openedx#open-release/redwood.nelp",
     "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1",
-    "@edx/frontend-platform": "npm:@edunext/frontend-platform@7.1.2-alpha.1",
+    "@edx/frontend-platform": "npm:@edunext/frontend-platform@^7.1.2-alpha-nelc.1",
     "@edx/openedx-atlas": "^0.6.0",
     "@edx/react-unit-test-utils": "npm:@edunext/react-unit-test-utils@2.0.0-alpha.1",
     "@openedx/frontend-plugin-framework": "github:edunext/frontend-plugin-framework#ednx-release/css-variables-1.2.2",


### PR DESCRIPTION
### Description

This updates frontend-platform and brand-openedx dependencies and finally set the custom styles [issue](https://edunext.atlassian.net/browse/FUTUREX-975)

#### How to test?
1. Delete node modules folder and run `npm install`
2. Open discussion -> the mfe must load with default color 
3. Add the following setting and check discussion page -> the mfe must load with red color
```
  "CUSTOM_PRIMARY_COLORS": {
    "pgn-color-primary-base": "#AA0000"
  },
```
4. Add the following setting and check discussion page -> the mfe must load with green color
```
  "PARAGON_THEME_URLS": {
    "core": {
        "url": "https://cdn.jsdelivr.net/combine/npm/@edx/paragon@22.0.0-alpha.13/styles/css/themes/light/utility-classes.min.css,npm/@edx/paragon@22.0.0-alpha.13/dist/core.min.css"
    },
    "defaults": {
        "light": "light"
    },
    "variants": {
        "light": {
            "url": "https://css-varsify.s3.amazonaws.com/public/a9959998-0bab-4447-ada5-6819866195f3.css"
        }
    }
  },
```
5. check the typography 

## Result
![image](https://github.com/user-attachments/assets/deccc6c6-3b78-42e3-b6dd-32ddcec5b2c7)
