### PR TITLE
feat: add workflow dispatch behaviour at mfe deployment

### DIFF
--- a/.github/workflows/deploy-mfe-s3.yml
+++ b/.github/workflows/deploy-mfe-s3.yml
@@ -1,18 +1,38 @@
+# This workflow deploys a Micro Frontend (MFE) application to an AWS S3 bucket
+# 
+# Purpose:
+# - Deploys the compiled frontend assets to an S3 bucket for hosting
+# - Uses a reusable workflow from nelc/actions-hub
+# - Can target either staging or production environments
+#
+# Trigger:
+# - Manual trigger only (workflow_dispatch)
+#
+# Inputs:
+# - environment: Choose between 'stage' (default) or 'prod' environments
+#
+# Notes:
+# - For production deployments, the workflow must be run from the production branch
+# - Stage deployments can be run from any branch
+
 name: MFE S3 Bucket Deployment 🚀
 
 on:
-  push:
-    branches:
-      - open-release/redwood.nelp
-      - open-rc/redwood.nelp
-
-  pull_request:
-    branches:
-       - "**open-rc**"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy:'
+        required: true
+        default: 'stage'
+        type: choice
+        options:
+          - stage
+          - prod
 
 jobs:
   deployment:
+    if: github.ref_name == github.event.repository.default_branch || inputs.environment == 'stage'
     uses: nelc/actions-hub/.github/workflows/mfe-s3-bucket-deployment.yml@main
     with:
-     PROD_BRANCH: 'open-release/redwood.nelp'
+      ENVIRONMENT: ${{ inputs.environment }}
     secrets: inherit


### PR DESCRIPTION
## Description
This pull request includes changes to the `.github/workflows/deploy-mfe-s3.yml` file to update the deployment workflow for a Micro Frontend (MFE) application to an AWS S3 bucket. The most important changes include switching to a manual trigger, adding environment input options, and updating the deployment conditions.

Workflow improvements:

* Switched the trigger from push and pull request events to a manual trigger (`workflow_dispatch`) with environment input options (`stage` or `prod`).
* Added deployment conditions to ensure production deployments only run from the default branch, while stage deployments can run from any branch.
* Updated the reusable workflow to use environment-specific inputs and removed the hardcoded production branch reference.