### PR TITLE
feat: add custom nelc dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.6.2",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+        "@edx/brand": "github:nelc/brand-openedx#open-release/teak.nelp",
         "@edx/frontend-component-footer": "^14.6.0",
         "@edx/frontend-component-header": "^6.4.0",
-        "@edx/frontend-platform": "^8.3.1",
+        "@edx/frontend-platform": "npm:@edunext/frontend-platform@^8.3.11",
         "@edx/openedx-atlas": "^0.6.0",
         "@edx/react-unit-test-utils": "^4.0.0",
         "@edx/reactifex": "^2.1.1",
@@ -2245,9 +2245,8 @@
     },
     "node_modules/@edx/brand": {
       "name": "@openedx/brand-openedx",
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
+      "version": "1.0.0-semantically-released",
+      "resolved": "git+ssh://git@github.com/nelc/brand-openedx.git#ae9e0a984330058859a186bb01ee1fe20fce28de",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/browserslist-config": {
@@ -2455,16 +2454,16 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-8.3.4.tgz",
-      "integrity": "sha512-V3XtTo3KP8QSmId+Vvi4+qzpOVkxvTMNA6jH/i3Bfz+/jHjHBRnmp/Cc2pjTxiTgGNoKX4D1twiZkOBO+kWw1Q==",
-      "license": "AGPL-3.0",
+      "name": "@edunext/frontend-platform",
+      "version": "8.3.11",
+      "resolved": "https://registry.npmjs.org/@edunext/frontend-platform/-/frontend-platform-8.3.11.tgz",
+      "integrity": "sha512-GyxT4AYDFQ5tR3M+4eJk0bFz+gpRLKTr0WCXWq0Lu77UcaZeBmvmrTsCSDfgdaoA6w9YwTyD+3XJmhH8jWqnKA==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
         "@formatjs/intl-relativetimeformat": "10.0.1",
-        "axios": "1.8.4",
-        "axios-cache-interceptor": "1.6.2",
+        "axios": "1.9.0",
+        "axios-cache-interceptor": "1.8.0",
         "form-urlencoded": "4.1.4",
         "glob": "7.2.3",
         "history": "4.10.1",
@@ -2493,17 +2492,12 @@
         "react-redux": "^7.1.1 || ^8.1.1",
         "react-router-dom": "^6.0.0",
         "redux": "^4.0.4"
-      }
-    },
-    "node_modules/@edx/frontend-platform/node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@openedx/frontend-build": {
+          "optional": true,
+          "reason": "This package is only a peer dependency to ensure using a minimum compatible version that provides env.config and PARAGON_THEME support. It is not needed at runtime, and may be omitted with `--omit=optional`."
+        }
       }
     },
     "node_modules/@edx/new-relic-source-map-webpack-plugin": {
@@ -4184,6 +4178,12 @@
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-error-boundary": "^4.0.11"
       }
+    },
+    "node_modules/@openedx/frontend-plugin-framework/node_modules/@edx/brand": {
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
+      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
     },
     "node_modules/@openedx/frontend-plugin-framework/node_modules/core-js": {
       "version": "3.37.1",
@@ -7141,11 +7141,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-      "license": "MIT",
-      "peer": true,
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -7153,10 +7151,9 @@
       }
     },
     "node_modules/axios-cache-interceptor": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-1.6.2.tgz",
-      "integrity": "sha512-YLbAODIHZZIcD4b3WYFVQOa5W2TY/WnJ6sBHqAg6Z+hx+RVj8/OcjQyRopO6awn7/kOkGL5X9TP16AucnlJ/lw==",
-      "license": "MIT",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-1.8.0.tgz",
+      "integrity": "sha512-cTNnPGJyQkxnWp0EWvE3NRvgURU5cWw/Qx3dIhXyHSM4Ip0c7EEe0I3an0Jwa549m1CAOg57ibj27YRNLmQCcg==",
       "dependencies": {
         "cache-parser": "1.2.5",
         "fast-defer": "1.1.8",
@@ -7802,8 +7799,7 @@
     "node_modules/cache-parser": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/cache-parser/-/cache-parser-1.2.5.tgz",
-      "integrity": "sha512-Md/4VhAHByQ9frQ15WD6LrMNiVw9AEl/J7vWIXw+sxT6fSOpbtt6LHTp76vy8+bOESPBO94117Hm2bIjlI7XjA==",
-      "license": "MIT"
+      "integrity": "sha512-Md/4VhAHByQ9frQ15WD6LrMNiVw9AEl/J7vWIXw+sxT6fSOpbtt6LHTp76vy8+bOESPBO94117Hm2bIjlI7XjA=="
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -11183,8 +11179,7 @@
     "node_modules/fast-defer": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/fast-defer/-/fast-defer-1.1.8.tgz",
-      "integrity": "sha512-lEJeOH5VL5R09j6AA0D4Uvq7AgsHw0dAImQQ+F3iSyHZuAxyQfWobsagGpTcOPvJr3urmKRHrs+Gs9hV+/Qm/Q==",
-      "license": "MIT"
+      "integrity": "sha512-lEJeOH5VL5R09j6AA0D4Uvq7AgsHw0dAImQQ+F3iSyHZuAxyQfWobsagGpTcOPvJr3urmKRHrs+Gs9hV+/Qm/Q=="
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -15927,8 +15922,7 @@
     "node_modules/object-code": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/object-code/-/object-code-1.3.3.tgz",
-      "integrity": "sha512-/Ds4Xd5xzrtUOJ+xJQ57iAy0BZsZltOHssnDgcZ8DOhgh41q1YJCnTPnWdWSLkNGNnxYzhYChjc5dgC9mEERCA==",
-      "license": "MIT"
+      "integrity": "sha512-/Ds4Xd5xzrtUOJ+xJQ57iAy0BZsZltOHssnDgcZ8DOhgh41q1YJCnTPnWdWSLkNGNnxYzhYChjc5dgC9mEERCA=="
     },
     "node_modules/object-filter": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "extends @edx/browserslist-config"
   ],
   "dependencies": {
-    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+    "@edx/brand": "github:nelc/brand-openedx#open-release/teak.nelp",
     "@edx/frontend-component-footer": "^14.6.0",
     "@edx/frontend-component-header": "^6.4.0",
-    "@edx/frontend-platform": "^8.3.1",
+    "@edx/frontend-platform": "npm:@edunext/frontend-platform@^8.3.11",
     "@edx/openedx-atlas": "^0.6.0",
     "@edx/react-unit-test-utils": "^4.0.0",
     "@edx/reactifex": "^2.1.1",

--- a/src/App.scss
+++ b/src/App.scss
@@ -13,3 +13,7 @@ $input-focus-box-shadow: var(--pgn-elevation-form-input-base); // hack to get up
 @import "./components/BulkManagementHistoryView/BulkManagementHistoryView";
 @import "./components/WithSidebar/WithSidebar";
 @import "./components/GradebookFilters/GradebookFilters";
+
+@import "@edx/brand/paragon/fonts";
+@import "@edx/brand/paragon/variables";
+@import "@edx/brand/paragon/overrides";


### PR DESCRIPTION
### Description

This set the edunext packages and add the openedx-brand styles to the main scss file. Migration pr of https://github.com/nelc/frontend-app-gradebook/pull/5

Issue # [1274](https://edunext.atlassian.net/browse/FUTUREX-1274)

### How to test?
1. run `npm install`
2. Open gradebook page -> the mfe must load with default color 
3. Add the following setting and check discussion page -> the mfe must load with red color
```
  "CUSTOM_PRIMARY_COLORS": {
    "pgn-color-primary-base": "#AA0000"
  },
```
4. Add the following setting and check discussion page -> the mfe must load with green color
```
  "PARAGON_THEME_URLS": {
    "core": {
        "url": "https://cdn.jsdelivr.net/combine/npm/@edx/paragon@22.0.0-alpha.13/styles/css/themes/light/utility-classes.min.css,npm/@edx/paragon@22.0.0-alpha.13/dist/core.min.css"
    },
    "defaults": {
        "light": "light"
    },
    "variants": {
        "light": {
            "url": "https://css-varsify.s3.amazonaws.com/public/a9959998-0bab-4447-ada5-6819866195f3.css"
        }
    }
  },
```
5. check the typography 

#### Expected result

<img width="1911" height="907" alt="image" src="https://github.com/user-attachments/assets/32f1c1c3-ed80-4620-9d2e-a34c68cb7677" />


