### PR TITLE
feat: add frontend-essentials translations to makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,10 @@ pull_translations:
 	           translations/frontend-component-header/src/i18n/messages:frontend-component-header \
 	           translations/frontend-platform/src/i18n/messages:frontend-platform \
 	           translations/paragon/src/i18n/messages:paragon \
-	           translations/frontend-app-gradebook/src/i18n/messages:frontend-app-gradebook
+	           translations/frontend-app-gradebook/src/i18n/messages:frontend-app-gradebook \
+	           translations/frontend-essentials/src/i18n/messages:frontend-essentials
 
-	$(intl_imports) frontend-platform paragon frontend-component-header frontend-component-footer frontend-app-gradebook
+	$(intl_imports) frontend-platform paragon frontend-component-header frontend-component-footer frontend-app-gradebook frontend-essentials
 
 # This target is used by CI.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
## Description

This adds the frontend-essentials package to the pull_translation workflow. 

Issue # [1535](https://edunext.atlassian.net/browse/FUTUREX-1535)

## How to test
1. Run the following commands
``` bash
export PATH="$(pwd)/node_modules/.bin:$PATH"
make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository=nelc/futurex-translations --revision=open-release/redwood.master" pull_translations
```
2. Check the content of the folder` frontend-app/gradebook/src/i18n/messages` 

<img width="686" height="593" alt="image" src="https://github.com/user-attachments/assets/a8b58ae9-e0a0-4576-bf69-e45582cdf30b" />
