### PR TITLE
feat: upgrade font with brand-opendx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2276,7 +2276,7 @@
     "node_modules/@edx/brand": {
       "name": "@openedx/brand-openedx",
       "version": "1.0.0-semantically-released",
-      "resolved": "git+ssh://git@github.com/nelc/brand-openedx.git#ae9e0a984330058859a186bb01ee1fe20fce28de",
+      "resolved": "git+ssh://git@github.com/nelc/brand-openedx.git#bd965c30ad0060db8c1f19defc385b539ac578a2",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/browserslist-config": {


### PR DESCRIPTION
# Description

feat: upgrade font with brand-opendx



## Before

<img width="1814" height="982" alt="Screenshot from 2026-01-20 15-32-48" src="https://github.com/user-attachments/assets/0506d07a-b636-4416-a6f4-79efea47aa69" />

## After

<img width="1828" height="1004" alt="Screenshot from 2026-01-20 15-34-07" src="https://github.com/user-attachments/assets/38fc74a7-bb06-4c8d-bfe1-826fc5acb062" />

